### PR TITLE
support `pg` driver

### DIFF
--- a/.changeset/clever-colts-march.md
+++ b/.changeset/clever-colts-march.md
@@ -1,0 +1,9 @@
+---
+"@enalmada/drizzle-helpers": patch
+---
+
+## Using `pg` as driver while creating a new repository
+
+Currently only `postgres` ( PostgresJS ) is supported as database driver.
+
+With this change, it's also possible to use `pg` ( node-postgres ) as driver.

--- a/src/DrizzleOrm.ts
+++ b/src/DrizzleOrm.ts
@@ -1,11 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/ban-ts-comment */
 import { and, asc, desc, eq } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { PgTableWithColumns } from "drizzle-orm/pg-core";
 import type { RelationalQueryBuilder } from "drizzle-orm/pg-core/query-builders/query";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { KnownKeysOnly } from "drizzle-orm/utils";
 
 type CriteriaType<T> = keyof T;
+
+type SchemaType = Record<string, unknown>;
+type DatabaseType<T extends SchemaType> =
+	| PostgresJsDatabase<T>
+	| NodePgDatabase<T>;
 
 const buildWhereClause = <T>(
 	// biome-ignore lint/suspicious/noExplicitAny: TBD
@@ -84,13 +90,13 @@ export interface IRepository<T, TI> {
 }
 
 export const createRepo = <
-	TSchema extends Record<string, unknown>,
+	TSchema extends SchemaType,
 	// biome-ignore lint/suspicious/noExplicitAny: TBD
 	T extends { [key: string]: any },
 	// biome-ignore lint/suspicious/noExplicitAny: TBD
 	TI extends { [key: string]: any },
 >(
-	db: PostgresJsDatabase<TSchema>, // replace with the appropriate type for db
+	db: DatabaseType<TSchema>, // replace with the appropriate type for db
 	// biome-ignore lint/suspicious/noExplicitAny: TBD
 	table: PgTableWithColumns<any>,
 	// biome-ignore lint/suspicious/noExplicitAny: TBD


### PR DESCRIPTION
Currently only `postgres` ( PostgresJS ) is supported as database driver inside the repository creating.

With the PR we would support also `pg` ( node-postgres ) as driver.

----

If there is something missing, please let me know and I will give my best to solve it :) 